### PR TITLE
Insect Glave: add support for customizing charging time

### DIFF
--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -7,6 +7,8 @@ local Module = {
             speed = -1,
             recovery = -1,
             unlimited_stamina = false,
+            fast_charge = false,
+            charge_time = 0,
         },
         red = false,
         white = false,
@@ -14,8 +16,6 @@ local Module = {
         infinite_air_attacks = false,
         fast_charge = false,
         charge_time = 0,
-        insect_fast_charge = false,
-        insect_charge_time = 0,
     }
 }
 
@@ -51,15 +51,18 @@ function Module.init_hooks()
         if not managed:get_Hunter():get_IsMaster() then return end
 
         -- Kinsect
-        if Module.data.kinsect.power > -1 or Module.data.kinsect.speed > -1 or Module.data.kinsect.recovery > -1 then 
-            local kinsect = managed:get_Insect()
-            update_field("kinsect", "_PowerLv", kinsect, Module.data.kinsect.power)
-            update_field("kinsect", "_SpeedLv", kinsect, Module.data.kinsect.speed)
-            update_field("kinsect", "_RecoveryLv", kinsect, Module.data.kinsect.recovery)
+        local kinsect = managed:get_Insect()
+        update_field("kinsect", "_PowerLv", kinsect, Module.data.kinsect.power)
+        update_field("kinsect", "_SpeedLv", kinsect, Module.data.kinsect.speed)
+        update_field("kinsect", "_RecoveryLv", kinsect, Module.data.kinsect.recovery)
+        
+        if Module.data.kinsect.unlimited_stamina then 
+            kinsect:get_field("Stamina"):set_field("_Value", 100.0)
+        end
             
-            if Module.data.kinsect.unlimited_stamina then 
-                kinsect:get_field("Stamina"):set_field("_Value", 100.0)
-            end
+        -- Insect charge
+        if Module.data.kinsect.fast_charge and managed:get_field("InsectChargeTimer") > Module.data.kinsect.charge_time/200 then
+            managed:set_field("InsectChargeTimer", 100.0)
         end
 
         -- Extracts
@@ -86,12 +89,6 @@ function Module.init_hooks()
             managed:set_field("_ChargeTimer", 100.0)
         end
 
-        -- Insect charge
-        if Module.data.insect_fast_charge and managed:get_field("InsectChargeTimer") > Module.data.insect_charge_time/200 then
-            managed:set_field("InsectChargeTimer", 100.0)
-        end
-
-
     end, function(retval) end)
 end
 
@@ -116,6 +113,21 @@ function Module.draw()
 
             changed, Module.data.kinsect.unlimited_stamina = imgui.checkbox(language.get(languagePrefix .. "unlimited_stamina"), Module.data.kinsect.unlimited_stamina)
             any_changed = any_changed or changed
+
+
+            changed, Module.data.kinsect.fast_charge = imgui.checkbox(language.get(languagePrefix .. "fast_charge"), Module.data.kinsect.fast_charge)
+            any_changed = any_changed or changed
+
+            if Module.data.kinsect.fast_charge then
+
+                imgui.same_line()
+                imgui.text("  ")
+                imgui.same_line()
+                imgui.set_next_item_width(imgui.calc_item_width() - 100)
+                changed, Module.data.kinsect.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.kinsect.charge_time, 0, 100, "%d")
+                utils.tooltip(language.get(languagePrefix.."charge_time_tooltip"))
+                any_changed = any_changed or changed
+            end
 
             imgui.tree_pop()
         end
@@ -147,25 +159,13 @@ function Module.draw()
         any_changed = any_changed or changed
 
         if Module.data.fast_charge then
+
             imgui.same_line()
             imgui.text("  ")
             imgui.same_line()
             imgui.set_next_item_width(imgui.calc_item_width() - 100)
             changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
             utils.tooltip(language.get(languagePrefix .. "charge_time_tooltip"))
-            any_changed = any_changed or changed
-        end
-
-        changed, Module.data.insect_fast_charge = imgui.checkbox(language.get(languagePrefix .. "insect_fast_charge"), Module.data.insect_fast_charge)
-        any_changed = any_changed or changed
-
-        if Module.data.insect_fast_charge then
-            imgui.same_line()
-            imgui.text("  ")
-            imgui.same_line()
-            imgui.set_next_item_width(imgui.calc_item_width() - 100)
-            changed, Module.data.insect_charge_time = imgui.slider_int(language.get(languagePrefix .. "insect_charge_time"), Module.data.insect_charge_time, 0, 100, "%d")
-            utils.tooltip(language.get(languagePrefix .. "insect_charge_time_tooltip"))
             any_changed = any_changed or changed
         end
 

--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -14,6 +14,8 @@ local Module = {
         infinite_air_attacks = false,
         fast_charge = false,
         charge_time = 0,
+        insect_fast_charge = false,
+        insect_charge_time = 0,
     }
 }
 
@@ -84,6 +86,11 @@ function Module.init_hooks()
             managed:set_field("_ChargeTimer", 100.0)
         end
 
+        -- Insect charge
+        if Module.data.insect_fast_charge and managed:get_field("InsectChargeTimer") > Module.data.insect_charge_time/200 then
+            managed:set_field("InsectChargeTimer", 100.0)
+        end
+
 
     end, function(retval) end)
 end
@@ -146,6 +153,19 @@ function Module.draw()
             imgui.set_next_item_width(imgui.calc_item_width() - 100)
             changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
             utils.tooltip(language.get(languagePrefix .. "charge_time_tooltip"))
+            any_changed = any_changed or changed
+        end
+
+        changed, Module.data.insect_fast_charge = imgui.checkbox(language.get(languagePrefix .. "insect_fast_charge"), Module.data.insect_fast_charge)
+        any_changed = any_changed or changed
+
+        if Module.data.insect_fast_charge then
+            imgui.same_line()
+            imgui.text("  ")
+            imgui.same_line()
+            imgui.set_next_item_width(imgui.calc_item_width() - 100)
+            changed, Module.data.insect_charge_time = imgui.slider_int(language.get(languagePrefix .. "insect_charge_time"), Module.data.insect_charge_time, 0, 100, "%d")
+            utils.tooltip(language.get(languagePrefix .. "insect_charge_time_tooltip"))
             any_changed = any_changed or changed
         end
 

--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -135,22 +135,19 @@ function Module.draw()
 
         changed, Module.data.infinite_air_attacks = imgui.checkbox(language.get(languagePrefix .. "infinite_air_attacks"), Module.data.infinite_air_attacks)
         any_changed = any_changed or changed
-
-        imgui.begin_table(Module.title.."1", 3, nil, nil, nil)
-        imgui.table_next_row()
-        imgui.table_next_column()
-
+        
         changed, Module.data.fast_charge = imgui.checkbox(language.get(languagePrefix .. "fast_charge"), Module.data.fast_charge)
         any_changed = any_changed or changed
 
-        imgui.table_next_column()
-
         if Module.data.fast_charge then
+            imgui.same_line()
+            imgui.text("  ")
+            imgui.same_line()
+            imgui.set_next_item_width(imgui.calc_item_width() - 100)
             changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
+            utils.tooltip(language.get(languagePrefix .. "charge_time_tooltip"))
             any_changed = any_changed or changed
         end
-
-        imgui.end_table()
 
         if any_changed then config.save_section(Module.create_config_section()) end
         imgui.unindent(10)

--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -12,7 +12,8 @@ local Module = {
         white = false,
         orange = false,
         infinite_air_attacks = false,
-        max_charge = false,
+        fast_charge = false,
+        charge_time = 0,
     }
 }
 
@@ -79,7 +80,7 @@ function Module.init_hooks()
         end
 
         -- Charge attack
-        if Module.data.max_charge and managed:get_field("_ChargeTimer") > 0 then 
+        if Module.data.fast_charge and managed:get_field("_ChargeTimer") > Module.data.charge_time/50 then
             managed:set_field("_ChargeTimer", 100.0)
         end
 
@@ -136,7 +137,10 @@ function Module.draw()
         any_changed = any_changed or changed
 
         
-        changed, Module.data.max_charge = imgui.checkbox(language.get(languagePrefix .. "max_charge"), Module.data.max_charge)
+        changed, Module.data.fast_charge = imgui.checkbox(language.get(languagePrefix .. "fast_charge"), Module.data.fast_charge)
+        any_changed = any_changed or changed
+
+        changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
         any_changed = any_changed or changed
 
         if any_changed then config.save_section(Module.create_config_section()) end

--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -136,12 +136,21 @@ function Module.draw()
         changed, Module.data.infinite_air_attacks = imgui.checkbox(language.get(languagePrefix .. "infinite_air_attacks"), Module.data.infinite_air_attacks)
         any_changed = any_changed or changed
 
-        
+        imgui.begin_table(Module.title.."1", 3, nil, nil, nil)
+        imgui.table_next_row()
+        imgui.table_next_column()
+
         changed, Module.data.fast_charge = imgui.checkbox(language.get(languagePrefix .. "fast_charge"), Module.data.fast_charge)
         any_changed = any_changed or changed
 
-        changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
-        any_changed = any_changed or changed
+        imgui.table_next_column()
+
+        if Module.data.fast_charge then
+            changed, Module.data.charge_time = imgui.slider_int(language.get(languagePrefix .. "charge_time"), Module.data.charge_time, 0, 100, "%d")
+            any_changed = any_changed or changed
+        end
+
+        imgui.end_table()
 
         if any_changed then config.save_section(Module.create_config_section()) end
         imgui.unindent(10)

--- a/data/Buffer/Languages/de-de.json
+++ b/data/Buffer/Languages/de-de.json
@@ -108,7 +108,8 @@
         "white": "Weiss",
         "infinite_air_attacks": "Unbegrenzte Luftangriffe",
         "fast_charge": "Schnelle Aufladung",
-        "charge_time": "Aufladezeit %"
+        "charge_time": "Aufladezeit %",
+        "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."
     },
 
     "hammer": {

--- a/data/Buffer/Languages/de-de.json
+++ b/data/Buffer/Languages/de-de.json
@@ -107,7 +107,8 @@
         "orange": "Orange",
         "white": "Weiss",
         "infinite_air_attacks": "Unbegrenzte Luftangriffe",
-        "max_charge": "Maximale Aufladung"
+        "fast_charge": "Schnelle Aufladung",
+        "charge_time": "Aufladezeit %"
     },
 
     "hammer": {

--- a/data/Buffer/Languages/de-de.json
+++ b/data/Buffer/Languages/de-de.json
@@ -109,7 +109,10 @@
         "infinite_air_attacks": "Unbegrenzte Luftangriffe",
         "fast_charge": "Schnelle Aufladung",
         "charge_time": "Aufladezeit %",
-        "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."
+        "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen.",
+        "insect_fast_charge": "Schnelle Kinsect Aufladung",
+        "insect_charge_time": "Kinsect Aufladezeit %",
+        "insect_charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."
     },
 
     "hammer": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -12,9 +12,8 @@
         "version": "Version"
     },
     "base": {
-        "disabled": "Disabled"        
+        "disabled": "Disabled"
     },
-    
     "character": {
         "title": "Character",
         "stamina": {
@@ -99,7 +98,10 @@
             "power": "Power",
             "speed": "Speed",
             "recovery": "Recovery",
-            "unlimited_stamina": "Unlimited Stamina"
+            "unlimited_stamina": "Unlimited Stamina",
+            "fast_charge": "Fast charge",
+            "charge_time": "Charge time %",
+            "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time.\n The smaller the value, the faster the charging."    
         },
         "red": "Red",
         "orange": "Orange",
@@ -107,10 +109,7 @@
         "infinite_air_attacks": "Infinite air attacks",
         "fast_charge": "Fast charge",
         "charge_time": "Charge time %",
-        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging.",
-        "insect_fast_charge": "Kinsect fast charge",
-        "insect_charge_time": "Kinsect charge time %",
-        "insect_charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging."
+        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time.\n The smaller the value, the faster the charging."    
     },
 
     "hammer": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -107,7 +107,10 @@
         "infinite_air_attacks": "Infinite air attacks",
         "fast_charge": "Fast charge",
         "charge_time": "Charge time %",
-        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging."
+        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging.",
+        "insect_fast_charge": "Kinsect fast charge",
+        "insect_charge_time": "Kinsect charge time %",
+        "insect_charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging."
     },
 
     "hammer": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -105,7 +105,8 @@
         "orange": "Orange",
         "white": "White",
         "infinite_air_attacks": "Infinite air attacks",
-        "max_charge": "Max charge"
+        "fast_charge": "Fast charge",
+        "charge_time": "Charge time %"
     },
 
     "hammer": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -106,7 +106,8 @@
         "white": "White",
         "infinite_air_attacks": "Infinite air attacks",
         "fast_charge": "Fast charge",
-        "charge_time": "Charge time %"
+        "charge_time": "Charge time %",
+        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time. The smaller the value, the faster the charging."
     },
 
     "hammer": {

--- a/data/Buffer/Languages/zh-cn.json
+++ b/data/Buffer/Languages/zh-cn.json
@@ -107,7 +107,10 @@
         "infinite_air_attacks": "无限空中攻击",
         "fast_charge": "快速充能",
         "charge_time": "充能时间%",
-        "charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。"
+        "charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。",
+        "insect_fast_charge": "猎虫快速充能",
+        "insect_charge_time": "猎虫充能时间%",
+        "insect_charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。"
     },
     "hammer": {
         "title": "锤子",

--- a/data/Buffer/Languages/zh-cn.json
+++ b/data/Buffer/Languages/zh-cn.json
@@ -105,7 +105,8 @@
         "orange": "橙灯",
         "white": "白灯",
         "infinite_air_attacks": "无限空中攻击",
-        "max_charge": "最大充能"
+        "fast_charge": "快速充能",
+        "charge_time": "充能时间%"
     },
     "hammer": {
         "title": "锤子",

--- a/data/Buffer/Languages/zh-cn.json
+++ b/data/Buffer/Languages/zh-cn.json
@@ -106,7 +106,8 @@
         "white": "白灯",
         "infinite_air_attacks": "无限空中攻击",
         "fast_charge": "快速充能",
-        "charge_time": "充能时间%"
+        "charge_time": "充能时间%",
+        "charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。"
     },
     "hammer": {
         "title": "锤子",

--- a/data/Buffer/Languages/zh-tw.json
+++ b/data/Buffer/Languages/zh-tw.json
@@ -109,7 +109,10 @@
         "infinite_air_attacks": "無限空中攻擊",
         "fast_charge": "快速充能",
         "charge_time": "充能時間%",
-        "charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。"
+        "charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。",
+        "insect_fast_charge": "獵蟲快速充能",
+        "insect_charge_time": "獵蟲充能時間%",
+        "insect_charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。"
     },
 
     "hammer": {

--- a/data/Buffer/Languages/zh-tw.json
+++ b/data/Buffer/Languages/zh-tw.json
@@ -108,7 +108,8 @@
         "white": "白色",
         "infinite_air_attacks": "無限空中攻擊",
         "fast_charge": "快速充能",
-        "charge_time": "充能時間%"
+        "charge_time": "充能時間%",
+        "charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。"
     },
 
     "hammer": {

--- a/data/Buffer/Languages/zh-tw.json
+++ b/data/Buffer/Languages/zh-tw.json
@@ -107,7 +107,8 @@
         "orange": "橙色",
         "white": "白色",
         "infinite_air_attacks": "無限空中攻擊",
-        "max_charge": "最大充能"
+        "fast_charge": "快速充能",
+        "charge_time": "充能時間%"
     },
 
     "hammer": {


### PR DESCRIPTION
Changed "max charge" to "fast charge". Add a UI element to set the charge time in percentage.
Setting a non-zero charge time (like 10%) allows to play uncharged and charged moves freely.