### PR TITLE
Ig unrestricted charge

### DIFF
--- a/autorun/Buffer/Modules/InsectGlaive.lua
+++ b/autorun/Buffer/Modules/InsectGlaive.lua
@@ -16,6 +16,7 @@ local Module = {
         infinite_air_attacks = false,
         fast_charge = false,
         charge_time = 0,
+        unrestricted_charge = false,
     }
 }
 
@@ -39,6 +40,13 @@ local function update_field(key, field_name, managed, new_value)
         managed:set_field(field_name, Module.old[key][field_name])
         Module.old[key][field_name] = nil
     end 
+end
+
+local shouldSkip = true
+local function updateChargeHook(args)
+    if Module.data.unrestricted_charge and shouldSkip then
+        return sdk.PreHookResult.SKIP_ORIGINAL
+    end
 end
 
 function Module.init_hooks()
@@ -90,7 +98,17 @@ function Module.init_hooks()
             managed:set_field("_ChargeTimer", 100.0)
         end
 
+        -- Free Charge
+        if Module.data.unrestricted_charge then
+            shouldSkip = false
+            managed:call("updateCharge")
+            shouldSkip = true
+        end
+
     end, function(retval) end)
+
+    sdk.hook(sdk.find_type_definition("app.cHunterWp10Handling"):get_method("updateCharge"), updateChargeHook, nil)
+
 end
 
 function Module.draw()
@@ -170,6 +188,10 @@ function Module.draw()
             utils.tooltip(language.get(languagePrefix .. "charge_time_tooltip"))
             any_changed = any_changed or changed
         end
+
+        changed, Module.data.unrestricted_charge = imgui.checkbox(language.get(languagePrefix .. "unrestricted_charge"), Module.data.unrestricted_charge)
+        utils.tooltip(language.get(languagePrefix .. "unrestricted_charge_tooltip"))
+        any_changed = any_changed or changed
 
         if any_changed then config.save_section(Module.create_config_section()) end
         imgui.unindent(10)

--- a/data/Buffer/Languages/de-de.json
+++ b/data/Buffer/Languages/de-de.json
@@ -123,7 +123,7 @@
             "unlimited_stamina": "Unendliche Ausdauer",
             "fast_charge": "Schnelle Kinsect Aufladung",
             "charge_time": "Kinsect Aufladezeit %",
-            "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."    
+            "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."
         },
         "red": "Rot",
         "orange": "Orange",
@@ -131,7 +131,9 @@
         "infinite_air_attacks": "Unbegrenzte Luftangriffe",
         "fast_charge": "Schnelle Aufladung",
         "charge_time": "Aufladezeit %",
-        "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen."
+        "charge_time_tooltip": "\"Aufladezeit %\" gibt an, wie viel Prozent der ursprünglichen Ladezeit für die maximale Ladung benötigt werden. Je kleiner der Wert, desto schneller das Aufladen.",
+        "unrestricted_charge": "Unbeschränkte Aufladen",
+        "unrestricted_charge_tooltip": "Ermöglicht Aufladen bei Aktionen, die es normalerweise nicht erlauben (z. B. während aufgeladener Angriffe oder mit weggesteckter Waffe)."    
     },
 
     "hammer": {
@@ -155,7 +157,7 @@
         "infinite_backstep": "Unendlicher Rueckwaertsschritt",
         "instant_charge": "Sofortige Aufladung", 
         "instant_charge_tooltip": "Man muss sie einen Moment lang festhalten und dann loslassen, um zu feuern.",
-        "free_charge_shot": "Kostenloser Schuss"
+        "unrestricted_charge_shot": "Kostenloser Schuss"
     },
 
     "bow": {

--- a/data/Buffer/Languages/de-de.json
+++ b/data/Buffer/Languages/de-de.json
@@ -157,7 +157,7 @@
         "infinite_backstep": "Unendlicher Rueckwaertsschritt",
         "instant_charge": "Sofortige Aufladung", 
         "instant_charge_tooltip": "Man muss sie einen Moment lang festhalten und dann loslassen, um zu feuern.",
-        "unrestricted_charge_shot": "Kostenloser Schuss"
+        "free_charge_shot": "Kostenloser Schuss"
     },
 
     "bow": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -154,7 +154,7 @@
         "infinite_backstep": "Infinite backstep",
         "instant_charge": "Instant charge", 
         "instant_charge_tooltip": "Will require being held for a moment, then letting go to fire",
-        "unrestricted_charge_shot": "Free charge shot"
+        "free_charge_shot": "Free charge shot"
     },
 
     "bow": {

--- a/data/Buffer/Languages/en-us.json
+++ b/data/Buffer/Languages/en-us.json
@@ -128,7 +128,9 @@
         "infinite_air_attacks": "Infinite air attacks",
         "fast_charge": "Fast charge",
         "charge_time": "Charge time %",
-        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time.\n The smaller the value, the faster the charging."    
+        "charge_time_tooltip": "\"Charge time %\" sets the required time to get the max charge in percentage to the original charge time.\n The smaller the value, the faster the charging.",
+        "unrestricted_charge": "Unrestricted charge",
+        "unrestricted_charge_tooltip": "Enable charging in some moves that normally don't allow it. (e.g. during charged attacks, and when the weapon is sheathed)"
     },
 
     "hammer": {
@@ -152,7 +154,7 @@
         "infinite_backstep": "Infinite backstep",
         "instant_charge": "Instant charge", 
         "instant_charge_tooltip": "Will require being held for a moment, then letting go to fire",
-        "free_charge_shot": "Free charge shot"
+        "unrestricted_charge_shot": "Free charge shot"
     },
 
     "bow": {

--- a/data/Buffer/Languages/zh-cn.json
+++ b/data/Buffer/Languages/zh-cn.json
@@ -129,7 +129,9 @@
         "infinite_air_attacks": "无限空中攻击",
         "fast_charge": "快速充能",
         "charge_time": "充能时间%",
-        "charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。"
+        "charge_time_tooltip": "\"充能时间%\"表示最大充能所需时间占原始充能时间的百分比。数值越小，充能越快。",
+        "unrestricted_charge": "无限制充能",
+        "unrestricted_charge_tooltip": "可以在某些原本不允许充能的动作中充能（如蓄力攻击中，收刀状态）"
     },
     "hammer": {
         "title": "锤子",
@@ -151,7 +153,7 @@
         "infinite_backstep": "无限后撤步",
         "instant_charge": "立即蓄力",
         "instant_charge_tooltip": "需保持蓄力片刻后松开方可发射",
-        "free_charge_shot": "免蓄力射击"
+        "unrestricted_charge_shot": "免蓄力射击"
     },
     "bow": {
         "title": "弓",

--- a/data/Buffer/Languages/zh-cn.json
+++ b/data/Buffer/Languages/zh-cn.json
@@ -153,7 +153,7 @@
         "infinite_backstep": "无限后撤步",
         "instant_charge": "立即蓄力",
         "instant_charge_tooltip": "需保持蓄力片刻后松开方可发射",
-        "unrestricted_charge_shot": "免蓄力射击"
+        "free_charge_shot": "免蓄力射击"
     },
     "bow": {
         "title": "弓",

--- a/data/Buffer/Languages/zh-tw.json
+++ b/data/Buffer/Languages/zh-tw.json
@@ -130,7 +130,9 @@
         "infinite_air_attacks": "無限空中攻擊",
         "fast_charge": "快速充能",
         "charge_time": "充能時間%",
-        "charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。"
+        "charge_time_tooltip": "\"充能時間%\"表示最大充能所需時間佔原始充能時間的百分比。數值越小，充能越快。",
+        "unrestricted_charge": "無限製充能",
+        "unrestricted_charge_tooltip": "可以在某些原本不允許充能的動作中充能（如蓄力攻擊中，收刀狀態）"
     },
 
     "hammer": {
@@ -154,7 +156,7 @@
         "infinite_backstep": "無限後跳",
         "instant_charge": "瞬間充能",
         "instant_charge_tooltip": "需要稍微按住一會兒，然後放開以發射",
-        "free_charge_shot": "免費充能射擊",
+        "unrestricted_charge_shot": "免費充能射擊",
         "max_charge": "最大充能"
     },
 

--- a/data/Buffer/Languages/zh-tw.json
+++ b/data/Buffer/Languages/zh-tw.json
@@ -156,7 +156,7 @@
         "infinite_backstep": "無限後跳",
         "instant_charge": "瞬間充能",
         "instant_charge_tooltip": "需要稍微按住一會兒，然後放開以發射",
-        "unrestricted_charge_shot": "免費充能射擊",
+        "free_charge_shot": "免費充能射擊",
         "max_charge": "最大充能"
     },
 


### PR DESCRIPTION
In this pr, I add an option and tooltip to IG to make charging possible during some moves that were originally impossible (eg. during charge attacks and when the weapons is sheathed). 

During some IG moves the function app.cHunterWp10Handling.updateCharge is not called, making it impossible to charge during such moves. The principle of this pr is to call app.cHunterWp10Handling.updateCharge in the hook of function app.cHunterWp10Handling.update. 

I find that calling this twice in a frame makes the charging speed doubled, this might be one solution to accelerate charging. (https://github.com/Bimmr/MHW-Buffer/pull/33#issuecomment-2715674404)